### PR TITLE
Platerun can exist in description file and not have a plate_data file…

### DIFF
--- a/src/ppv/parse_platedata.py
+++ b/src/ppv/parse_platedata.py
@@ -4,22 +4,27 @@ from .util import paths
 from astropy.table import Table, vstack
 
 
-plateruns = list(_fp_available)
-platedata_paths = [paths.fp_platedata(prun) for prun in plateruns]
+# plateruns are all plateruns that are availble with platedata files.
+# see fiveplates module for call
 
-prun_to_path = dict(zip(plateruns, platedata_paths))
 
-pruns_to_parse_path = dict(filter(lambda prun_path: prun_path[1], prun_to_path.items()))
-pruns_to_parse = list(pruns_to_parse_path.keys())
+def fp_plateplans(plateruns):
+    platedata_paths = [paths.fp_platedata(prun) for prun in plateruns]
 
-platedata_tables = [io.load_fp_platedata(prun) for prun
-                    in pruns_to_parse]
+    prun_to_path = dict(zip(plateruns, platedata_paths))
 
-platedata_tables = list(filter(None, platedata_tables))
+    pruns_to_parse_path = dict(filter(lambda prun_path: prun_path[1], prun_to_path.items()))
+    pruns_to_parse = list(pruns_to_parse_path.keys())
 
-main_platedata = vstack(platedata_tables)
-main_platedata.add_index('fieldname')
-main_platedata.add_index('designid')
+    platedata_tables = [io.load_fp_platedata(prun) for prun
+                        in pruns_to_parse]
+
+    platedata_tables = list(filter(None, platedata_tables))
+
+    main_platedata = vstack(platedata_tables)
+    main_platedata.add_index('fieldname')
+    main_platedata.add_index('designid')
+    return main_platedata
 
 
 

--- a/src/ppv/util/paths.py
+++ b/src/ppv/util/paths.py
@@ -132,17 +132,12 @@ def fp_platedata(platerun):
     """
 
     _guess = f'plate_data_{platerun}*.txt'
+
     pd_file_s = filter(lambda F: fnmatch.fnmatch(F, _guess),
                        fp_files(platerun))
-    # Assuming only one file is retuned
-    try:
-        pd_files = list(pd_file_s)
-        if len(pd_files) == 1:
-            pd_file = pd_files[0]
-        else:
-            pd_file = list(filter(lambda F: 'initial' in F, pd_files))[0]
-        return fiveplates_platerun(platerun) / pd_file
-    except StopIteration:
+
+    pd_files = list(pd_file_s)
+    if len(pd_files) == 0:  # no plate data yet
         _message = f'''\
                        Unable to load fiveplates plate data file for:
                        {platerun}.
@@ -153,6 +148,12 @@ def fp_platedata(platerun):
                     '''
         print(_message)
         return None
+    else:
+        if len(pd_files) == 1:
+            pd_file = pd_files[0]
+        else:
+            pd_file = list(filter(lambda F: 'initial' in F, pd_files))[0]
+        return fiveplates_platerun(platerun) / pd_file
 
 
 def fp_defaultparams(platerun):


### PR DESCRIPTION
… in it. Rewrote parse_platedata to get five_plates main plateplans to account for this.

The paths fuction can now account for zero plate_data files. I also preprocess the list of available plateruns now. If a platerun has no plate_data file in it, the parse_platedata module will ignore it. Only call to parse_platedata is in fiveplates.
