### PR TITLE
Proper incorporation of apogee_STA file in targetlists

### DIFF
--- a/src/ppv/data/io.py
+++ b/src/ppv/data/io.py
@@ -243,8 +243,13 @@ def fp_platedef_params(platerun, field, designID):
 
 def fp_plateinput(platerun, field, designID, inputfile):
     targetlists_zip = paths.fiveplates_targetlists(platerun)
-    with ZipFile(os.fspath(targetlists_zip)) as tl_zip:
-        pl_input_path_str = f'{paths.fp_field_designID_dir(field, designID)}/{inputfile}'
-        with tl_zip.open(pl_input_path_str, 'r') as pl_input:
-            data = Table.read(pl_input, format='ascii.commented_header')
+    try:
+        with ZipFile(os.fspath(targetlists_zip)) as tl_zip:
+            pl_input_path_str = f'{paths.fp_field_designID_dir(field, designID)}/{inputfile}'
+            with tl_zip.open(pl_input_path_str, 'r') as pl_input:
+                data = Table.read(pl_input, format='ascii.commented_header')
+    except KeyError:   # The file was not in the zip archive
+        print(f'warning: {paths.fp_field_designID_dir(field, designID)}/{inputfile} does not exist.')
+        print(f'please ignore if platerun was prior to MWM_04')
+        return None
     return data

--- a/src/ppv/fiveplates.py
+++ b/src/ppv/fiveplates.py
@@ -19,7 +19,7 @@ import numpy as np
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
-from astropy.table import vstack, Column
+from astropy.table import vstack, Column, Table
 from astropy.io import ascii
 import os
 
@@ -233,6 +233,11 @@ class Field:
     def _process_plateinput(self, targetlist_filename):
         targetlist_table = io.fp_plateinput(self.platerun, self.name,
                                             self.designID, targetlist_filename)
+        if targetlist_table == None:
+            # NO targetlist_table exists! This is for plateruns before MWM_04
+            empty_table = Table()
+            return empty_table
+
         priority_program_name = parse_program_name_from_file(self.name, self.designID,
                                                              targetlist_filename)
         instrument = parse_instrument_name_from_file(self.name, self.designID,
@@ -249,10 +254,10 @@ class Field:
 
     def _full_plateinput_table(self):
         _plateinput_filenames = plateInput_files(self._platedef_params)
-        # APOGEE standards made separately! ARRGGGHHH
+        # APOGEE standards made separately prior to MWM_04! ARRGGGHHH
         plinput_tables = [self._process_plateinput(targetlist_file) for
-                          targetlist_file in _plateinput_filenames if
-                          'apogee_STA' not in targetlist_file]
+                          targetlist_file in _plateinput_filenames]
+        # if 'apogee_STA' not in targetlist_file]
         full_table = vstack(plinput_tables)
         full_table.rename_column('Catalog_id', 'catalogid')
         full_table.sort('catalogid')


### PR DESCRIPTION
Since MWM_04, the apogee_STA carton now appears in the targetlists.zip file. However, even since before MWM_04, the platedefintion file listed the apogee_STA carton as a targetlist file. At the time, this file was added ad hoc after five_plates was complete (by querying Simbad). 

Now this is fixed in five_plates, so this PR incorporates the apogee_STA targetlist file when it exists, and gracefully ignores it for previous plateruns.

